### PR TITLE
Correctly handle string table names with fallback langs

### DIFF
--- a/Smartling.i18n/Smartling.i18n/NSBundle+Smartling_i18n.m
+++ b/Smartling.i18n/Smartling.i18n/NSBundle+Smartling_i18n.m
@@ -33,21 +33,22 @@
 	for (NSString *lang in locales) {
 		const char* form = pluralformf([lang cStringUsingEncoding:NSASCIIStringEncoding], pluralValue);
 		NSString *keyVariant = [NSString stringWithFormat:@"%@##{%s}", key, form];
-		
-		if (tableName.length == 0) {
-			tableName = @"Localizable";
+
+		NSString *langTableName = tableName;
+		if (langTableName.length == 0) {
+			langTableName = @"Localizable";
 		}
-		if (tableName) {
-			tableName = [self pathForResource:tableName ofType:@"strings" inDirectory:nil forLocalization:lang];
+		if (langTableName) {
+			langTableName = [self pathForResource:langTableName ofType:@"strings" inDirectory:nil forLocalization:lang];
 		}
-		if (!tableName) {
+		if (!langTableName) {
 			NSArray *paths = [self pathsForResourcesOfType:@"strings" inDirectory:nil forLocalization:lang];
-			if (paths.count) tableName = paths[0];
+			if (paths.count) langTableName = paths[0];
 		}
 		
 		NSDictionary *dict = nil;
-		if (tableName) {
-			dict = [NSDictionary dictionaryWithContentsOfFile:tableName];
+		if (langTableName) {
+			dict = [NSDictionary dictionaryWithContentsOfFile:langTableName];
 		}
 		
 		NSString *ls = dict[keyVariant];


### PR DESCRIPTION
Prior to this change, if you passed a custom table name and used a language where a fallback language was used to determine the pluralization rule, the tableName variable would be passed to `[self pathForResource:...]` multiple times. On the second time, passing an absolute string would produce a nil result.

This would happen, for example, for Mexican Spanish, where the lang list is ("es_MX", "es-MX", "es", "English"), and "es" determines the pluralization rule.
