### PR TITLE
Correctly handle string table names with fallback langs

### DIFF
--- a/Smartling.i18n/Smartling.i18n/NSBundle+Smartling_i18n.m
+++ b/Smartling.i18n/Smartling.i18n/NSBundle+Smartling_i18n.m
@@ -29,26 +29,37 @@
 	if (self.developmentLocalization && ![[locales lastObject] isEqualToString:self.developmentLocalization]) {
 		[locales addObject:self.developmentLocalization];
 	}
-	
+
+	if (tableName.length == 0) {
+		tableName = @"Localizable";
+	}
+	if (tableName) {
+		for (NSString *lang in locales) {
+			NSString *newTableName = [self pathForResource:tableName ofType:@"strings" inDirectory:nil forLocalization:lang];
+			if (newTableName != nil) {
+				tableName = newTableName;
+				break;
+			}
+		}
+	}
+	if (!tableName) {
+		for (NSString *lang in locales) {
+			NSArray *paths = [self pathsForResourcesOfType:@"strings" inDirectory:nil forLocalization:lang];
+			if (paths.count) {
+				tableName = paths[0];
+				break;
+			}
+		}
+	}
+
+	NSDictionary *dict = nil;
+	if (tableName) {
+		dict = [NSDictionary dictionaryWithContentsOfFile:tableName];
+	}
+
 	for (NSString *lang in locales) {
 		const char* form = pluralformf([lang cStringUsingEncoding:NSASCIIStringEncoding], pluralValue);
 		NSString *keyVariant = [NSString stringWithFormat:@"%@##{%s}", key, form];
-		
-		if (tableName.length == 0) {
-			tableName = @"Localizable";
-		}
-		if (tableName) {
-			tableName = [self pathForResource:tableName ofType:@"strings" inDirectory:nil forLocalization:lang];
-		}
-		if (!tableName) {
-			NSArray *paths = [self pathsForResourcesOfType:@"strings" inDirectory:nil forLocalization:lang];
-			if (paths.count) tableName = paths[0];
-		}
-		
-		NSDictionary *dict = nil;
-		if (tableName) {
-			dict = [NSDictionary dictionaryWithContentsOfFile:tableName];
-		}
 		
 		NSString *ls = dict[keyVariant];
 		if (ls.length) {


### PR DESCRIPTION
In the case of dialect locales like es-MX (with a language list like "es_MX", "es-MX", "es", "English") the old code had two interrelated problems:
- It assumed that the language code used to determine the pluralization rule (in the example, "es") would be the same one used to select the string table localization, which does not make sense.
- By using the same variable for the string table name and the resolved path, it ended up passing absolute paths to `[self pathForResource:...]`, which returned nil on the second iteration.
