### PR TITLE
Added 'foundation' import

### DIFF
--- a/Smartling.i18n/SLLocalization.h
+++ b/Smartling.i18n/SLLocalization.h
@@ -24,6 +24,7 @@
 //   SLPluralizedStringFromTableInBundle(key, tbl, bundle, n, comment)
 //   SLPluralizedStringWithDefaultValue(key, tbl, bundle, n, val, comment)
 
+#import <Foundation/Foundation.h>
 
 @interface NSBundle (Smartling_i18n)
 


### PR DESCRIPTION
Hi! 
I've installed `smartling-i18n` with cocoapods. And now I unable to build my project. 
It's because my project doesn't use `pch`-file with `Foundation` import. (last XCode project templates doesn't use them neither).
So, I've added `#import <Foundation/Foundation.h>` to `SLLocalization.h`.