### PR TITLE
[podspec] remove supported platforms

### DIFF
--- a/Smartling.i18n.podspec
+++ b/Smartling.i18n.podspec
@@ -6,10 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'APACHE', :file => 'LICENSE' }
   s.author       = 'Pavel Ivashkov'
 
-  s.ios.platform = :ios, '3.2'
   s.ios.deployment_target = '3.2'
-
-  s.osx.platform = :osx, '10.4'
   s.osx.deployment_target = '10.6'
 
   s.source       = { :git => 'https://github.com/Smartling/ios-i18n.git', :tag => "v#{s.version}" }


### PR DESCRIPTION
# Description
http://guides.cocoapods.org/syntax/podspec.html#platform says:
> When supporting multiple platforms you should use deployment_target below instead.

This pull request removes the supported platforms form the podspec. 

# Resolved Issue
This library can not be installed with cocoapods 1.0.0.
