### PR TITLE
Missed watchos deployment target added to podspec

### DIFF
--- a/Smartling.i18n.podspec
+++ b/Smartling.i18n.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '3.2'
   s.osx.deployment_target = '10.6'
+  s.watchos.deployment_target = '2.0'
 
   s.source       = { :git => 'https://github.com/Smartling/ios-i18n.git', :tag => "v#{s.version}" }
   s.source_files = 'Smartling.i18n/*.{h,m,c}'


### PR DESCRIPTION
We have used previous version of this library and it has supported watch os. So maybe it is a good decision to return it back.