### PR TITLE
replace strcat with strlcat

### DIFF
--- a/Smartling.i18n/NSBundle+Smartling_i18n.m
+++ b/Smartling.i18n/NSBundle+Smartling_i18n.m
@@ -79,8 +79,8 @@
 	
 	const char* form = pluralformf([lang cStringUsingEncoding:NSASCIIStringEncoding], pluralValue);
 	char suffix[16] = "##{";
-	strcat(suffix, form);
-	strcat(suffix, "}");
+	strlcat(suffix, form, sizeof(suffix));
+	strlcat(suffix, "}", sizeof(suffix));
 	NSString *keyVariant = [key stringByAppendingString:[NSString stringWithUTF8String:suffix]];
 	NSDictionary *dict = [self stringsWithContentsOfFile:tableName forLocalization:locale];
 	NSString *ls = dict[keyVariant];


### PR DESCRIPTION
Hi there,

To prevent future buffer overflows, I think it would be best to use strlcat() instead of strcat().
Reference: https://www.us-cert.gov/bsi/articles/knowledge/coding-practices/strcpy-and-strcat

Thanks!