### PR TITLE
Fix Carthage import

### DIFF
--- a/Smartling.i18n/SmartlingLib.h
+++ b/Smartling.i18n/SmartlingLib.h
@@ -19,10 +19,10 @@
 //
 
 //! Project version number for SmartlingLib.
-FOUNDATION_EXPORT double SmartlingLibVersionNumber;
+extern double SmartlingLibVersionNumber;
 
 //! Project version string for SmartlingLib.
-FOUNDATION_EXPORT const unsigned char SmartlingLibVersionString[];
+extern const unsigned char SmartlingLibVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <SmartlingLib/PublicHeader.h>
 


### PR DESCRIPTION
Hi, 

when trying to import ios-i18n using Carthage I got the error
> Unknown type name "FOUNDATION_EXPORT"

So I've changed it to `extern`.